### PR TITLE
Hotfix triggering

### DIFF
--- a/fus_ds_package/fus_driving_systems/igt/igt_ds.py
+++ b/fus_ds_package/fus_driving_systems/igt/igt_ds.py
@@ -117,6 +117,8 @@ class IGT(ds.ControlDrivingSystem):
 
         self.sent_seqs[seq_num]['total_sequence_duration_ms'] = total_sequence_duration_ms + 100
 
+        logger.debug(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
+
     def connect(self, connect_info, log_dir='C:\\Temp', log_name='standalone_igt', attempt=0):
         """
         Connects to the IGT ultrasound driving system.

--- a/fus_ds_package/fus_driving_systems/igt/igt_ds.py
+++ b/fus_ds_package/fus_driving_systems/igt/igt_ds.py
@@ -117,7 +117,7 @@ class IGT(ds.ControlDrivingSystem):
 
         self.sent_seqs[seq_num]['total_sequence_duration_ms'] = total_sequence_duration_ms + 100
 
-        logger.debug(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
+        logger.info(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
 
     def connect(self, connect_info, log_dir='C:\\Temp', log_name='standalone_igt', attempt=0):
         """

--- a/fus_ds_package/fus_driving_systems/sequence.py
+++ b/fus_ds_package/fus_driving_systems/sequence.py
@@ -498,12 +498,12 @@ class Sequence():
                                       True, True, True, False)
         if is_validated:
             self._n_triggers = n_triggers
-            
+
             # set temporarily the pulse train repetition parameters equal to
-            # the pulse train duration to prevent default being lower than 
+            # the pulse train duration to prevent default being lower than
             # pulse train duration
             self.pulse_train_rep_int = self.pulse_train_dur
-            self.pulse_train_rep_dur = self.pulse_train_dur
+            self.pulse_train_rep_dur = self.pulse_train_dur / 1e3  # convert from ms to s
 
     @property
     def transducer(self):


### PR DESCRIPTION
Due to incorrect unit of the pulse train repetition duration when using TriggerSequence, the system was unresponsive for 1000 times longer time than it should be.