### PR TITLE
Hotfix triggering

### DIFF
--- a/fus_ds_package/fus_driving_systems/igt/igt_ds.py
+++ b/fus_ds_package/fus_driving_systems/igt/igt_ds.py
@@ -117,6 +117,8 @@ class IGT(ds.ControlDrivingSystem):
 
         self.sent_seqs[seq_num]['total_sequence_duration_ms'] = total_sequence_duration_ms + 100
 
+        logger.debug(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
+
     def connect(self, connect_info, log_dir='C:\\Temp', log_name='standalone_igt', attempt=0):
         """
         Connects to the IGT ultrasound driving system.

--- a/fus_ds_package/fus_driving_systems/igt/igt_ds.py
+++ b/fus_ds_package/fus_driving_systems/igt/igt_ds.py
@@ -117,7 +117,7 @@ class IGT(ds.ControlDrivingSystem):
 
         self.sent_seqs[seq_num]['total_sequence_duration_ms'] = total_sequence_duration_ms + 100
 
-        logger.debug(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
+        logger.info(f"Stored sequence {seq_num}: {self.sent_seqs[seq_num]}")
 
     def connect(self, connect_info, log_dir='C:\\Temp', log_name='standalone_igt', attempt=0):
         """

--- a/fus_ds_package/fus_driving_systems/sequence.py
+++ b/fus_ds_package/fus_driving_systems/sequence.py
@@ -498,12 +498,12 @@ class Sequence():
                                       True, True, True, False)
         if is_validated:
             self._n_triggers = n_triggers
-            
+
             # set temporarily the pulse train repetition parameters equal to
-            # the pulse train duration to prevent default being lower than 
+            # the pulse train duration to prevent default being lower than
             # pulse train duration
             self.pulse_train_rep_int = self.pulse_train_dur
-            self.pulse_train_rep_dur = self.pulse_train_dur
+            self.pulse_train_rep_dur = self.pulse_train_dur / 1e3  # convert from ms to s
 
     @property
     def transducer(self):

--- a/standalone_driving_system_software/interleaved_example/sequences/sequence_17_26_ch.py
+++ b/standalone_driving_system_software/interleaved_example/sequences/sequence_17_26_ch.py
@@ -79,7 +79,6 @@ def create_sequence_collection(logger):
     # based on the set focus.
     seq3.dephasing_degree = None  # [degrees]: None, [120] or [0, 135, 239, 90]
 
-    # THE FEATURE IS NOT ENABLED YET! Use amplitude only for now
     # either set maximum pressure in free water [MPa], voltage [V] or amplitude [%]
     seq3.press = 0  # [MPa], maximum pressure in free water
     # seq3.volt = 0  # [V], voltage per channel
@@ -119,7 +118,6 @@ def create_sequence_collection(logger):
         # based on the set focus.
         seq4.dephasing_degree = None  # [degrees]: None, [120] or [0, 135, 239, 90]
 
-        # THE FEATURE IS NOT ENABLED YET! Use amplitude only for now
         # either set maximum pressure in free water [MPa], voltage [V] or amplitude [%]
         seq4.press = 0.5  # [MPa], maximum pressure in free water
         # seq4.volt = 0  # [V], voltage per channel

--- a/standalone_driving_system_software/interleaved_example/sequences/sequence_1_10_ch.py
+++ b/standalone_driving_system_software/interleaved_example/sequences/sequence_1_10_ch.py
@@ -119,7 +119,6 @@ def create_sequence_collection(logger):
         # based on the set focus.
         seq2.dephasing_degree = None  # [degrees]: None, [120] or [0, 135, 239, 90]
 
-        # THE FEATURE IS NOT ENABLED YET! Use amplitude only for now
         # either set maximum pressure in free water [MPa], voltage [V] or amplitude [%]
         seq2.press = 0  # [MPa], maximum pressure in free water
         # seq2.volt = 0  # [V], voltage per channel

--- a/standalone_driving_system_software/interleaved_example/sequences/sequence_1_10_ch.py
+++ b/standalone_driving_system_software/interleaved_example/sequences/sequence_1_10_ch.py
@@ -80,7 +80,6 @@ def create_sequence_collection(logger):
     # based on the set focus.
     seq1.dephasing_degree = None  # [degrees]: None, [120] or [0, 135, 239, 90]
 
-    # THE FEATURE IS NOT ENABLED YET! Use amplitude only for now
     # either set maximum pressure in free water [MPa], voltage [V] or amplitude [%]
     seq1.press = 0.5  # [MPa], maximum pressure in free water
     # seq1.volt = 0  # [V], voltage per channel


### PR DESCRIPTION
Due to incorrect unit of the pulse train repetition duration when using TriggerSequence, the system was unresponsive for 1000 times longer time than it should be.